### PR TITLE
Meeting managers may delete not decided items, ignoring the WFA 'only…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,8 @@ Products.MeetingSeraing Changelog
   [gbastien]
 - MeetingManager may now edit MeetingManager fields in 'accepted', 'accepted_but_modified', 'delayed' states.
   [aduchene]
-
+- MeetingManager may delete every not decided items, ignoring the WFA 'only_creators_may_delete'.
+  [aduchene]
 
 4.2.1 (2023-08-23)
 ------------------

--- a/src/Products/MeetingSeraing/configure.zcml
+++ b/src/Products/MeetingSeraing/configure.zcml
@@ -68,4 +68,8 @@
 
    </configure>
 
+  <adapter for="Products.PloneMeeting.interfaces.IMeetingItem"
+       factory=".adapters.CustomSeraingMeetingItemContentDeletableAdapter"
+       provides="imio.actionspanel.interfaces.IContentDeletable" />
+
 </configure>


### PR DESCRIPTION
…_creators_may_delete'